### PR TITLE
Добавление возможности пользователем вводить адрес используемого сервера API вместе с ключами доступа

### DIFF
--- a/Planfix_API.php
+++ b/Planfix_API.php
@@ -22,11 +22,6 @@ class Planfix_API_Exception extends Exception {}
 class Planfix_API {
 
     /**
-     * Url that handles API requests
-     */
-    const API_URL = 'https://api.planfix.ru/xml/';
-
-    /**
      * Version of the library
      */
     const VERSION = '1.0.1';
@@ -51,6 +46,13 @@ class Planfix_API {
      * Maximum simultaneous Curl handles in a Multi Curl session
      */
     public static $MAX_BATCH_SIZE = 10;
+
+    /**
+     * Api url
+     *
+     * @var string
+     */
+    protected $apiUrl;
 
     /**
      * Api key
@@ -98,14 +100,36 @@ class Planfix_API {
      * Initializes a Planfix Client
      *
      * Required parameters:
+     *    - apiUrl - API Url
      *    - apiKey - Application Key
      *    - apiSecret - Application Secret
      *
      * @param array $config The array containing required parameters
      */
     public function __construct($config) {
+        $this->setApiUrl($config['apiUrl']);
         $this->setApiKey($config['apiKey']);
         $this->setApiSecret($config['apiSecret']);
+    }
+
+    /**
+     * Set the Api url
+     *
+     * @param string $apiUrl Api url
+     * @return Planfix_API
+     */
+    public function setApiUrl($apiUrl) {
+        $this->apiUrl = $apiUrl;
+        return $this;
+    }
+
+    /**
+     * Get the Api url
+     *
+     * @return string the Api url
+     */
+    public function getApiUrl() {
+        return $this->apiUrl;
     }
 
     /**
@@ -509,7 +533,7 @@ class Planfix_API {
      * @return resource the Curl handle
      */
     protected function prepareCurlHandle($requestXml) {
-        $ch = curl_init(self::API_URL);
+        $ch = curl_init($this->getApiUrl());
 
         curl_setopt_array($ch, self::$CURL_OPTS);
 

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ PHP Planfix client (Planfix_API) v.1.0.1
 1. Подключаем клиент:
 
         require 'Planfix_API.php';
-        $PF = new Planfix_API(array('apiKey' => 'YOUR_API_KEY', 'apiSecret' => 'YOUR_API_SECRET'));
+        $PF = new Planfix_API(array('apiUrl' => 'YOUR_API_URL', 'apiKey' => 'YOUR_API_KEY', 'apiSecret' => 'YOUR_API_SECRET'));
         $PF->setAccount('YOUR_ACCOUNT');
 
-   Подразумевается, что у вас уже есть ApiKey и ApiSecret. Получить их можно [здесь](http://planfix.ru/dev.html).
+   Подразумевается, что у вас уже есть ApiUrl, ApiKey и ApiSecret. Получить их можно [здесь](http://planfix.ru/dev.html).
    Создаем обьект клиента и устанавливаем аккаунт в ПланФиксе ({аккаунт}.planfix.ru).
 
 2. Проходим процедуру авторизации пользователя:


### PR DESCRIPTION
При регистрации аккаунта в планфиксе на выбор предлагается 2 места расположения сервера: в России и в Европе. Для доступа к API в интерфейсе планфикса кроме ключа доступа и секретного ключа выдается еще и адрес сервера, которых два

`https://apiru.planfix.ru/xml` - сервер в России
`https://api.planfix.ru/xml` - сервер в Европе

Нужно иметь возможность указывать адрес сервера, предлагаю добавить это первым параметром при создании объекта

`new Planfix_API(array('apiUrl' => 'YOUR_API_URL', 'apiKey' => 'YOUR_API_KEY', 'apiSecret' => 'YOUR_API_SECRET'))`

Это будет удобно, потому что эти 3 параметра находятся на одной странице настройки доступа к API в интерфейсе планфикса



