### PR TITLE
Добавление поддержки редиректа при использовании адреса сервиса API без слеша в конце

### DIFF
--- a/Planfix_API.php
+++ b/Planfix_API.php
@@ -44,7 +44,9 @@ class Planfix_API {
         CURLOPT_RETURNTRANSFER    => 1,
         CURLOPT_TIMEOUT           => 60,
         CURLOPT_SSL_VERIFYPEER    => 0,
-        CURLOPT_SSL_VERIFYHOST    => 0
+        CURLOPT_SSL_VERIFYHOST    => 0,
+        CURLOPT_FOLLOWLOCATION    => 1,
+        CURLOPT_POSTREDIR         => 1
     );
 
     /**


### PR DESCRIPTION
В админке планфикса url для доступа к api приводится без слеша в конце, но сервер api делает редирект на адрес со слешем, поэтому хорошим решением добавить поддержку этого редиректа с сохранением содержимого post-запроса. Имеет смысл после применения ранее предложенного poll-реквеста

